### PR TITLE
chore: add contributors to `README.md`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,37 @@
+{
+  "projectName": "testing-playground",
+  "projectOwner": "smeijer",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "smeijer",
+      "name": "Stephan Meijer",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/1196524?v=4",
+      "profile": "https://github.com/smeijer",
+      "contributions": [
+        "ideas",
+        "code",
+        "infra",
+        "maintenance"
+      ]
+    },
+    {
+      "login": "marcosvega91",
+      "name": "Marco Moretti",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/5365582?v=4",
+      "profile": "https://github.com/marcosvega91",
+      "contributions": [
+        "code",
+        "test"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Testing-Playground ([demo])
 
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 **Playground for [testing-library/dom]**
 
 ![screenshot of unimported results](./docs/testing-playground-com.gif)
@@ -11,11 +17,35 @@ Testing-Playground provides you with direct feedback. Trying to visualize the di
 [testing-library/dom]: https://testing-library.com/docs/dom-testing-library/example-intro
 [demo]: https://testing-playground.com
 
-# Roadmap
+## Roadmap
 
 Future ideas are maintained in the [roadmap]. Please use the [issue tracker] to discuss any questions or suggestions you have.
 
 Every section in the roadmap is accompanied by one or more issues. Contributions are most welcome!
 
+## Contributors
+
+Thanks goes to these people ([emoji key][emojis]):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/smeijer"><img src="https://avatars1.githubusercontent.com/u/1196524?v=4" width="100px;" alt=""/><br /><sub><b>Stephan Meijer</b></sub></a><br /><a href="#ideas-smeijer" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/smeijer/testing-playground/commits?author=smeijer" title="Code">💻</a> <a href="#infra-smeijer" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#maintenance-smeijer" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/marcosvega91"><img src="https://avatars2.githubusercontent.com/u/5365582?v=4" width="100px;" alt=""/><br /><sub><b>Marco Moretti</b></sub></a><br /><a href="https://github.com/smeijer/testing-playground/commits?author=marcosvega91" title="Code">💻</a> <a href="https://github.com/smeijer/testing-playground/commits?author=marcosvega91" title="Tests">⚠️</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors][all-contributors] specification.
+Contributions of any kind welcome!
+
 [roadmap]: https://github.com/smeijer/testing-playground/blob/master/ROADMAP.md
 [issue tracker]: https://github.com/smeijer/testing-playground/issues
+[all-contributors]: https://github.com/all-contributors/all-contributors
+[emojis]: https://github.com/all-contributors/all-contributors#emoji-key


### PR DESCRIPTION
To quote the all-contributors page:

> The basic idea is this:
> 
> Use the project README to recognize the contributions of members of the project community.
> 
> People are giving themselves and their free time to contribute to open source projects in so many ways, so we believe everyone should be praised for their contributions (code or not).

As a reminder, contributors can be added in two ways:

**command line**
```
npx all-contributors-cli add <username> <contributions>
```

**bot**
```
@all-contributors please add <username> for <contributions>
```

Contributions are comma-separated, and the types can be found here:

https://allcontributors.org/docs/en/emoji-key

---

resolves: #6 