### PR TITLE
chore: silence tailwind purge css error

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  purge: false,
+};


### PR DESCRIPTION
Because we are using a custom PostCSS config, tailwind was logging warnings during build:

>    ⚠️  Tailwind is not purging unused styles because no template paths have been provided.
>      If you have manually configured PurgeCSS outside of Tailwind or are deliberately not
      removing unused styles, set `purge: false` in your Tailwind config file to silence
      this warning.
>   
>      https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css

I've done exactly that.