### PR TITLE
fix: escape invalid id's to prevent WSOD

### DIFF
--- a/src/lib/queryAdvise.js
+++ b/src/lib/queryAdvise.js
@@ -6,8 +6,12 @@ export function getData({ root, element }) {
   const type = element.getAttribute('type');
   const tagName = element.tagName;
 
-  // prevent querySelector from tripping over corrupted html like <input id="button\n<button>
-  const id = (element.getAttribute('id') || '').split('\n')[0];
+  // escape id to prevent querySelector from tripping over corrupted html like:
+  //   <input id="button\n<button> & <input id=\ntype="text" />
+  const id = (element.getAttribute('id') || '')
+    .replace(/\s/g, '')
+    .replace(/"/g, '\\"');
+
   const labelElem = id ? root.querySelector(`[for="${id}"]`) : null;
   const labelText = labelElem ? labelElem.innerText : null;
 


### PR DESCRIPTION
Incorrect `id` attributes, can lead to a white-screen. One example of an invalid query that causing this is:

```html
<button 
  id=
  name="submit" 
/>
```

```js
container.querySelector('button')
```

[playground](https://testing-playground.com/#DwIwrgLhD2B2AEBLAJgXlgQwLYFNUCIBnMELRCfeAegD4g&MYewdgLghglmCmAnAdARwK5IJ4GV4Bt5gIREAKAcgCN0ISwKBKIA)


Everyone understands that this isn't valid HTML, but... it happens when we are typing in the editor.