### PR TITLE
feat: make oembed requests default to json type

### DIFF
--- a/src/lambda/oembed/oembed.js
+++ b/src/lambda/oembed/oembed.js
@@ -19,12 +19,12 @@ function getHostname(event, context) {
 function handler(event, context, callback) {
   const host = getHostname(event, context);
   const params = event.queryStringParameters;
-  
-  if (params.format === 'xml') {	
-    return callback(	
-      null,	
-      incorrectParams('unsupported format, only json is supported'),	
-    );	
+
+  if (params.format === 'xml') {
+    return callback(
+      null,
+      incorrectParams('unsupported format, only json is supported'),
+    );
   }
 
   if (!params.url) {

--- a/src/lambda/oembed/oembed.js
+++ b/src/lambda/oembed/oembed.js
@@ -19,6 +19,13 @@ function getHostname(event, context) {
 function handler(event, context, callback) {
   const host = getHostname(event, context);
   const params = event.queryStringParameters;
+  
+  if (params.format === 'xml') {	
+    return callback(	
+      null,	
+      incorrectParams('unsupported format, only json is supported'),	
+    );	
+  }
 
   if (!params.url) {
     return callback(

--- a/src/lambda/oembed/oembed.js
+++ b/src/lambda/oembed/oembed.js
@@ -20,13 +20,6 @@ function handler(event, context, callback) {
   const host = getHostname(event, context);
   const params = event.queryStringParameters;
 
-  if (params.format !== 'json') {
-    return callback(
-      null,
-      incorrectParams('unsupported format, only json is supported'),
-    );
-  }
-
   if (!params.url) {
     return callback(
       null,


### PR DESCRIPTION
No need to pass `format` if their's only one.

We can make it default to `json` whenever we would want to support `xml` format too