### PR TITLE
fix: restore quotes around oembed iframe attributes

### DIFF
--- a/src/lambda/oembed/oembed.js
+++ b/src/lambda/oembed/oembed.js
@@ -50,7 +50,7 @@ function handler(event, context, callback) {
         author_name: 'Testing Playground',
         author_url: host,
 
-        html: `<iframe src="${url}" width=${maxwidth} height=${maxheight} scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="true" title="Testing Playground" style="overflow: hidden; display: block;" loading="lazy" name="testing-playground-${Date.now()}"></iframe>`,
+        html: `<iframe src="${url}" width="${maxwidth}" height="${maxheight}" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="true" title="Testing Playground" style="overflow: hidden; display: block;" loading="lazy" name="testing-playground-${Date.now()}"></iframe>`,
         width: maxwidth,
         height: maxheight,
 


### PR DESCRIPTION
Add quotes around `width` & `height`