### PR TITLE
feat: evaluate javascript query in a sandbox

### DIFF
--- a/src/components/Context.js
+++ b/src/components/Context.js
@@ -1,27 +1,17 @@
-import React, { useContext, useCallback, useRef, useState } from 'react';
+import React, { useContext, useRef, useState } from 'react';
 
 export const AppContext = React.createContext();
 
 function AppContextProvider(props) {
   const jsEditorRef = useRef();
   const htmlEditorRef = useRef();
-  const [htmlRoot, setHtmlRoot] = useState();
   const [parsed, setParsed] = useState({});
-
-  const setHtmlRootRef = useCallback(
-    (node) => {
-      setHtmlRoot(node);
-    },
-    [setHtmlRoot],
-  );
 
   return (
     <AppContext.Provider
       value={{
         jsEditorRef,
         htmlEditorRef,
-        htmlRoot,
-        setHtmlRootRef,
         parsed,
         setParsed,
       }}

--- a/src/components/Embedded.js
+++ b/src/components/Embedded.js
@@ -14,14 +14,6 @@ import MarkupEditor from './MarkupEditor';
 
 const savedState = state.load();
 
-const styles = {
-  offscreen: {
-    position: 'absolute',
-    left: -300,
-    width: 100,
-  },
-};
-
 const SUPPORTED_PANES = {
   markup: true,
   preview: true,
@@ -33,7 +25,7 @@ const SUPPORTED_PANES = {
 function Embedded() {
   const [html, setHtml] = useState(savedState.markup || initialValues.html);
   const [js, setJs] = useState(savedState.query || initialValues.js);
-  const { setParsed, htmlRoot } = useAppContext();
+  const { setParsed } = useAppContext();
 
   const location = useLocation();
   const params = queryString.parse(location.search);
@@ -58,16 +50,12 @@ function Embedded() {
       : 'grid-cols-1';
 
   useEffect(() => {
-    if (!htmlRoot) {
-      return;
-    }
-
-    const parsed = parser.parse({ htmlRoot, js });
+    const parsed = parser.parse({ markup: html, query: js });
     setParsed(parsed);
 
     state.save({ markup: html, query: js });
     state.updateTitle(parsed.expression?.expression);
-  }, [html, js, htmlRoot]);
+  }, [html, js]);
 
   useEffect(() => {
     document.body.classList.add('embedded');
@@ -78,13 +66,6 @@ function Embedded() {
     <div
       className={`h-full overflow-hidden grid grid-flow-col gap-4 p-4 bg-white shadow rounded ${columnClass}`}
     >
-      {/*the markup preview must always be rendered!*/}
-      {!panes.includes('preview') && (
-        <div style={styles.offscreen}>
-          <Preview html={html} />
-        </div>
-      )}
-
       {panes.map((area) => {
         switch (area) {
           case 'preview':

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -16,19 +16,15 @@ function Playground() {
   const [html, setHtml] = useState(savedState.markup || initialValues.html);
   const [js, setJs] = useState(savedState.query || initialValues.js);
 
-  const { setParsed, htmlRoot } = useAppContext();
+  const { setParsed } = useAppContext();
 
   useEffect(() => {
-    if (!htmlRoot) {
-      return;
-    }
-
-    const parsed = parser.parse({ htmlRoot, js });
+    const parsed = parser.parse({ markup: html, query: js });
     setParsed(parsed);
 
     state.save({ markup: html, query: js });
     state.updateTitle(parsed.expression?.expression);
-  }, [htmlRoot, html, js]);
+  }, [html, js]);
 
   return (
     <div className="flex flex-col h-auto md:h-full w-full">

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,10 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useAppContext } from './Context';
 import Scrollable from './Scrollable';
 import PreviewHint from './PreviewHint';
 import { getQueryAdvise } from '../lib';
 
-function Preview({ html }) {
+function selectByCssPath(rootNode, cssPath) {
+  return rootNode?.querySelector(cssPath.replace(/^body > /, ''));
+}
+
+function Preview() {
   // Okay, listen up. `highlighted` can be a number of things, as I wanted to
   // keep a single variable to represent the state. This to reduce bug count
   // by creating out-of-sync states.
@@ -21,41 +25,49 @@ function Preview({ html }) {
   //    Indicating that the `parsed` element can be highlighted again.
   const [highlighted, setHighlighted] = useState(false);
   const [roles, setRoles] = useState([]);
+  const { parsed, jsEditorRef } = useAppContext();
+  const htmlRoot = useRef();
 
-  const { parsed, jsEditorRef, htmlRoot, setHtmlRootRef } = useAppContext();
-
-  const { advise } = getQueryAdvise({
-    root: htmlRoot ? htmlRoot.firstChild : null,
+  const { suggestion } = getQueryAdvise({
+    rootNode: htmlRoot.current ? htmlRoot.current.firstChild : null,
     element: highlighted,
   });
 
+  // TestingLibraryDom?.getSuggestedQuery(highlighted, 'get').toString() : null
+
   useEffect(() => {
-    setRoles(Object.keys(parsed.roles || {}).sort());
-  }, [parsed.roles]);
+    setRoles(Object.keys(parsed.accessibleRoles || {}).sort());
+  }, [parsed.accessibleRoles]);
 
   useEffect(() => {
     if (highlighted) {
-      parsed.targets?.forEach((el) => el.classList.remove('highlight'));
+      parsed.elements?.forEach((el) => {
+        const target = selectByCssPath(htmlRoot.current, el.cssPath);
+        target?.classList.remove('highlight');
+      });
       highlighted.classList?.add('highlight');
     } else {
       highlighted?.classList?.remove('highlight');
 
       if (highlighted === false) {
-        parsed.targets?.forEach((el) => el.classList.add('highlight'));
+        parsed.elements?.forEach((el) => {
+          const target = selectByCssPath(htmlRoot.current, el.cssPath);
+          target?.classList.add('highlight');
+        });
       }
     }
 
     return () => highlighted?.classList?.remove('highlight');
-  }, [highlighted, parsed.targets]);
+  }, [highlighted, parsed.elements]);
 
   const handleClick = (event) => {
-    if (event.target === htmlRoot) {
+    if (event.target === htmlRoot.current) {
       return;
     }
 
     event.preventDefault();
     const expression =
-      advise.expression ||
+      suggestion.expression ||
       '// No recommendation available.\n// Add some html attributes, or\n// use container.querySelector(…)';
     jsEditorRef.current.setValue(expression);
   };
@@ -84,15 +96,15 @@ function Preview({ html }) {
         <Scrollable>
           <div
             className="preview"
-            ref={setHtmlRootRef}
             onClick={handleClick}
             onMouseMove={handleMove}
-            dangerouslySetInnerHTML={{ __html: html }}
+            ref={htmlRoot}
+            dangerouslySetInnerHTML={{ __html: parsed.markup }}
           />
         </Scrollable>
       </div>
 
-      <PreviewHint roles={roles} advise={advise} />
+      <PreviewHint roles={roles} suggestion={suggestion} />
     </div>
   );
 }

--- a/src/components/PreviewHint.js
+++ b/src/components/PreviewHint.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Expandable from './Expandable';
 
-function PreviewHint({ roles, advise }) {
-  const expression = advise.expression ? (
-    `> ${advise.expression}`
+function PreviewHint({ roles, suggestion }) {
+  const expression = suggestion.expression ? (
+    `> ${suggestion.expression}`
   ) : (
     <>
       <span className="font-bold">accessible roles: </span>

--- a/src/components/Query.js
+++ b/src/components/Query.js
@@ -12,7 +12,7 @@ function Query({ onChange, initialValue }) {
         <QueryEditor initialValue={initialValue} onChange={onChange} />
       </div>
 
-      <QueryOutput error={parsed.error} result={parsed.text} />
+      <QueryOutput error={parsed.error?.message} result={parsed.formatted} />
     </div>
   );
 }

--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -3,31 +3,32 @@ import ErrorBox from './ErrorBox';
 import ResultQueries from './ResultQueries';
 import ResultSuggestion from './ResultSuggestion';
 import { useAppContext } from './Context';
-import { getQueryAdvise } from '../lib';
 import Scrollable from './Scrollable';
 
 function Result() {
-  const { parsed, htmlRoot } = useAppContext();
-  const element = parsed.target;
+  const { parsed } = useAppContext();
 
   if (parsed.error) {
-    return <ErrorBox caption={parsed.error} body={parsed.errorBody} />;
+    return (
+      <ErrorBox caption={parsed.error.message} body={parsed.error.details} />
+    );
   }
 
-  const { data, advise } = getQueryAdvise({
-    root: htmlRoot,
-    element,
-  });
+  const { data, suggestion } = parsed.elements?.[0] || {};
+
+  if (!data || !suggestion) {
+    return <div />;
+  }
 
   return (
     <div className="flex flex-col overflow-hidden w-full h-full">
       <div className="flex-none pb-4 border-b">
-        <ResultSuggestion data={data} advise={advise} />
+        <ResultSuggestion data={data} suggestion={suggestion} />
       </div>
 
       <div className="flex-auto">
         <Scrollable>
-          <ResultQueries data={data} advise={advise} />
+          <ResultQueries data={data} suggestion={suggestion} />
         </Scrollable>
       </div>
     </div>

--- a/src/components/ResultSuggestion.js
+++ b/src/components/ResultSuggestion.js
@@ -8,37 +8,37 @@ function Code({ children }) {
   return <span className="font-bold font-mono">{children}</span>;
 }
 
-function ResultSuggestion({ data, advise }) {
+function ResultSuggestion({ data, suggestion }) {
   const { parsed, jsEditorRef } = useAppContext();
 
   const used = parsed?.expression || {};
 
-  const usingAdvisedMethod = advise.method === used.method;
+  const usingAdvisedMethod = suggestion.method === used.method;
   const hasNameArg = data.name && used.args?.[1]?.includes('name');
 
-  const color = usingAdvisedMethod ? 'bg-green-600' : colors[advise.level];
+  const color = usingAdvisedMethod ? 'bg-green-600' : colors[suggestion.level];
 
   const target = parsed.target || {};
 
-  let suggestion;
+  let message;
 
-  if (advise.level < used.level) {
-    suggestion = (
+  if (suggestion.level < used.level) {
+    message = (
       <p>
         You&apos;re using <Code>{used.method}</Code>, which falls under{' '}
         <Code>{messages[used.level].heading}</Code>. Upgrading to{' '}
-        <Code>{advise.method}</Code> is recommended.
+        <Code>{suggestion.method}</Code> is recommended.
       </p>
     );
-  } else if (advise.level === 0 && advise.method !== used.method) {
-    suggestion = (
+  } else if (suggestion.level === 0 && suggestion.method !== used.method) {
+    message = (
       <p>
         Nice! <Code>{used.method}</Code> is a great selector! Using{' '}
-        <Code>{advise.method}</Code> would still be preferable though.
+        <Code>{suggestion.method}</Code> would still be preferable though.
       </p>
     );
   } else if (target.tagName === 'INPUT' && !target.getAttribute('type')) {
-    suggestion = (
+    message = (
       <p>
         You can unlock <Code>getByRole</Code> by adding the{' '}
         <Code>type=&quot;text&quot;</Code> attribute explicitly. Accessibility
@@ -46,11 +46,11 @@ function ResultSuggestion({ data, advise }) {
       </p>
     );
   } else if (
-    advise.level === 0 &&
-    advise.method === 'getByRole' &&
+    suggestion.level === 0 &&
+    suggestion.method === 'getByRole' &&
     !data.name
   ) {
-    suggestion = (
+    message = (
       <p>
         Awesome! This is great already! You could still make the query a bit
         more specific by adding the name option. This would require to add some
@@ -58,19 +58,19 @@ function ResultSuggestion({ data, advise }) {
       </p>
     );
   } else if (
-    advise.level === 0 &&
-    advise.method === 'getByRole' &&
+    suggestion.level === 0 &&
+    suggestion.method === 'getByRole' &&
     data.name &&
     !hasNameArg
   ) {
-    suggestion = (
+    message = (
       <p>
         There is one thing though. You could make the query a bit more specific
         by adding the name option.
       </p>
     );
   } else if (used.level > 0) {
-    suggestion = (
+    message = (
       <p>
         This isn&apos;t great, but we can&apos;t do better with the current
         markup. Extend your html to improve accessibility and unlock better
@@ -78,27 +78,28 @@ function ResultSuggestion({ data, advise }) {
       </p>
     );
   } else {
-    suggestion = <p>This is great. Ship it!</p>;
+    message = <p>This is great. Ship it!</p>;
   }
 
   const handleClick = () => {
-    jsEditorRef.current.setValue(advise.expression);
+    jsEditorRef.current.setValue(suggestion.expression);
   };
 
   return (
     <div className="space-y-4 text-sm">
       <div className={['text-white p-4 rounded space-y-2', color].join(' ')}>
         <div className="font-bold text-xs">suggested query</div>
-        {advise.expression && (
+        {suggestion.expression && (
           <div
             className="font-mono cursor-pointer text-xs"
             onClick={handleClick}
           >
-            &gt; {advise.expression}
+            &gt; {suggestion.expression}
+            <br />
           </div>
         )}
       </div>
-      <div className="min-h-8">{suggestion}</div>
+      <div className="min-h-8">{message}</div>
     </div>
   );
 }

--- a/src/lib/cssPath.js
+++ b/src/lib/cssPath.js
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2011 Google Inc.  All rights reserved.
+ * Copyright (C) 2007, 2008 Apple Inc.  All rights reserved.
+ * Copyright (C) 2008 Matt Lilek <webkit@mattlilek.com>
+ * Copyright (C) 2009 Joseph Pecoraro
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Apple Computer, Inc. ("Apple") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+const WebInspector = {
+  DOMPresentationUtils: {},
+};
+
+/**
+ * @return {string}
+ */
+function nodeNameInCorrectCase(node) {
+  let shadowRootType = node.shadowRootType;
+  if (shadowRootType) {
+    return '#shadow-root (' + shadowRootType + ')';
+  }
+  return node.xmlVersion ? node.nodeName : node.nodeName.toLowerCase();
+}
+
+/**
+ * @param {!WebInspector.DOMNode} node
+ * @param {boolean=} optimized
+ * @return {string}
+ */
+WebInspector.DOMPresentationUtils.cssPath = function (node, optimized) {
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return '';
+  }
+
+  let steps = [];
+  let contextNode = node;
+  while (contextNode) {
+    let step = WebInspector.DOMPresentationUtils._cssPathStep(
+      contextNode,
+      !!optimized,
+      contextNode === node,
+    );
+    if (!step) {
+      break; // Error - bail out early.
+    }
+    steps.push(step);
+    if (step.optimized) {
+      break;
+    }
+    contextNode = contextNode.parentNode;
+  }
+
+  steps.reverse();
+  return steps.join(' > ');
+};
+
+/**
+ * @param {!WebInspector.DOMNode} node
+ * @param {boolean} optimized
+ * @param {boolean} isTargetNode
+ * @return {?WebInspector.DOMNodePathStep}
+ */
+WebInspector.DOMPresentationUtils._cssPathStep = function (
+  node,
+  optimized,
+  isTargetNode,
+) {
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return null;
+  }
+
+  let id = node.getAttribute('id');
+  if (optimized) {
+    if (id) {
+      return new WebInspector.DOMNodePathStep(idSelector(id), true);
+    }
+    let nodeNameLower = node.nodeName.toLowerCase();
+    if (
+      nodeNameLower === 'body' ||
+      nodeNameLower === 'head' ||
+      nodeNameLower === 'html'
+    ) {
+      return new WebInspector.DOMNodePathStep(
+        nodeNameInCorrectCase(node),
+        true,
+      );
+    }
+  }
+  let nodeName = nodeNameInCorrectCase(node);
+
+  if (id) {
+    return new WebInspector.DOMNodePathStep(nodeName + idSelector(id), true);
+  }
+  let parent = node.parentNode;
+  if (!parent || parent.nodeType === Node.DOCUMENT_NODE) {
+    return new WebInspector.DOMNodePathStep(nodeName, true);
+  }
+
+  /**
+   * @param {!WebInspector.DOMNode} node
+   * @return {!Array.<string>}
+   */
+  function prefixedElementClassNames(node) {
+    let classAttribute = node.getAttribute('class');
+    if (!classAttribute) {
+      return [];
+    }
+
+    return classAttribute
+      .split(/\s+/g)
+      .filter(Boolean)
+      .map(function (name) {
+        // The prefix is required to store "__proto__" in a object-based map.
+        return '$' + name;
+      });
+  }
+
+  /**
+   * @param {string} id
+   * @return {string}
+   */
+  function idSelector(id) {
+    return '#' + escapeIdentifierIfNeeded(id);
+  }
+
+  /**
+   * @param {string} ident
+   * @return {string}
+   */
+  function escapeIdentifierIfNeeded(ident) {
+    if (isCSSIdentifier(ident)) {
+      return ident;
+    }
+    let shouldEscapeFirst = /^(?:[0-9]|-[0-9-]?)/.test(ident);
+    let lastIndex = ident.length - 1;
+    return ident.replace(/./g, function (c, i) {
+      return (shouldEscapeFirst && i === 0) || !isCSSIdentChar(c)
+        ? escapeAsciiChar(c, i === lastIndex)
+        : c;
+    });
+  }
+
+  /**
+   * @param {string} c
+   * @param {boolean} isLast
+   * @return {string}
+   */
+  function escapeAsciiChar(c, isLast) {
+    return '\\' + toHexByte(c) + (isLast ? '' : ' ');
+  }
+
+  /**
+   * @param {string} c
+   */
+  function toHexByte(c) {
+    let hexByte = c.charCodeAt(0).toString(16);
+    if (hexByte.length === 1) {
+      hexByte = '0' + hexByte;
+    }
+    return hexByte;
+  }
+
+  /**
+   * @param {string} c
+   * @return {boolean}
+   */
+  function isCSSIdentChar(c) {
+    if (/[a-zA-Z0-9_-]/.test(c)) {
+      return true;
+    }
+    return c.charCodeAt(0) >= 0xa0;
+  }
+
+  /**
+   * @param {string} value
+   * @return {boolean}
+   */
+  function isCSSIdentifier(value) {
+    return /^-?[a-zA-Z_][a-zA-Z0-9_-]*$/.test(value);
+  }
+
+  let prefixedOwnClassNamesArray = prefixedElementClassNames(node);
+  let needsClassNames = false;
+  let needsNthChild = false;
+  let ownIndex = -1;
+  let elementIndex = -1;
+  let siblings = parent.children;
+  for (
+    let i = 0;
+    (ownIndex === -1 || !needsNthChild) && i < siblings.length;
+    ++i
+  ) {
+    let sibling = siblings[i];
+    if (sibling.nodeType !== Node.ELEMENT_NODE) {
+      continue;
+    }
+    elementIndex += 1;
+    if (sibling === node) {
+      ownIndex = elementIndex;
+      continue;
+    }
+    if (needsNthChild) {
+      continue;
+    }
+    if (nodeNameInCorrectCase(sibling) !== nodeName) {
+      continue;
+    }
+
+    needsClassNames = true;
+    let ownClassNames = prefixedOwnClassNamesArray.keySet;
+    let ownClassNameCount = 0;
+    // eslint-disable-next-line no-unused-vars
+    for (let name in ownClassNames) {
+      ++ownClassNameCount;
+    }
+    if (ownClassNameCount === 0) {
+      needsNthChild = true;
+      continue;
+    }
+    let siblingClassNamesArray = prefixedElementClassNames(sibling);
+    for (let j = 0; j < siblingClassNamesArray.length; ++j) {
+      let siblingClass = siblingClassNamesArray[j];
+      // eslint-disable-next-line no-prototype-builtins
+      if (!ownClassNames.hasOwnProperty(siblingClass)) {
+        continue;
+      }
+      delete ownClassNames[siblingClass];
+      if (!--ownClassNameCount) {
+        needsNthChild = true;
+        break;
+      }
+    }
+  }
+
+  let result = nodeName;
+  if (
+    isTargetNode &&
+    nodeName.toLowerCase() === 'input' &&
+    node.getAttribute('type') &&
+    !node.getAttribute('id') &&
+    !node.getAttribute('class')
+  ) {
+    result += '[type="' + node.getAttribute('type') + '"]';
+  }
+  if (needsNthChild) {
+    result += ':nth-child(' + (ownIndex + 1) + ')';
+  } else if (needsClassNames) {
+    for (let prefixedName in prefixedOwnClassNamesArray.keySet) {
+      result += '.' + escapeIdentifierIfNeeded(prefixedName.substr(1));
+    }
+  }
+
+  return new WebInspector.DOMNodePathStep(result, false);
+};
+
+WebInspector.DOMNodePathStep = function (value, optimized) {
+  this.value = value;
+  this.optimized = optimized || false;
+};
+
+WebInspector.DOMNodePathStep.prototype = {
+  /**
+   * @override
+   * @return {string}
+   */
+  toString() {
+    return this.value;
+  },
+};
+
+const cssPath = WebInspector.DOMPresentationUtils.cssPath;
+export default cssPath;

--- a/src/lib/queryAdvise.js
+++ b/src/lib/queryAdvise.js
@@ -2,7 +2,7 @@ import { messages, queries } from '../constants';
 import { getExpression } from './getExpression';
 import { computeAccessibleName, getRole } from 'dom-accessibility-api';
 
-export function getData({ root, element }) {
+export function getData({ rootNode, element }) {
   const type = element.getAttribute('type');
   const tagName = element.tagName;
 
@@ -12,7 +12,7 @@ export function getData({ root, element }) {
     .replace(/\s/g, '')
     .replace(/"/g, '\\"');
 
-  const labelElem = id ? root.querySelector(`[for="${id}"]`) : null;
+  const labelElem = id ? rootNode.querySelector(`[for="${id}"]`) : null;
   const labelText = labelElem ? labelElem.innerText : null;
 
   return {
@@ -35,29 +35,29 @@ export function getData({ root, element }) {
   };
 }
 
-export function getQueryAdvise({ root, element }) {
-  if (!root || element?.nodeType !== Node.ELEMENT_NODE) {
-    return { data: {}, advise: {} };
+export function getQueryAdvise({ rootNode, element }) {
+  if (!rootNode || element?.nodeType !== Node.ELEMENT_NODE) {
+    return { data: {}, suggestion: {} };
   }
 
-  const data = getData({ root, element });
+  const data = getData({ rootNode, element });
   const query = queries.find(({ method }) => getExpression({ method, data }));
 
   if (!query) {
     return {
       level: 3,
       expression: 'container.querySelector(…)',
-      advise: {},
+      suggestion: {},
       data,
       ...messages[3],
     };
   }
 
   const expression = getExpression({ method: query.method, data });
-  const advise = { expression, ...query, ...messages[query.level] };
+  const suggestion = { expression, ...query, ...messages[query.level] };
 
   return {
     data,
-    advise,
+    suggestion,
   };
 }

--- a/src/plugin.html
+++ b/src/plugin.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>TL Embedded</title>
+  </head>
+
+  <style>
+    body {
+      background: #ccc;
+    }
+  </style>
+  <body>
+    <!--
+    This is a test file to test the embed mode,
+    to try this run `npm run start`, and after that run
+    `npm run start:embed` in a second terminal
+
+  -->
+
+    <div>
+      <input type="checkbox">
+      <input type="checkbox" disabled>
+      <input type="checkbox" checked>
+      <input type="checkbox" checked disabled>
+    </div>
+    <div>
+      <input type="radio">
+      <input type="radio" disabled>
+      <input type="radio" checked>
+      <input type="radio" checked disabled>
+    </div>
+    <div>
+      <input type="button" value="Button">
+      <input type="button" value="Button" disabled>
+    </div>
+    <div>
+      <input type="text" value="value"><br>
+      <input type="text" value="value" disabled>
+    </div>
+    <div>
+      <textarea>value</textarea><br>
+      <textarea disabled>value</textarea>
+    </div>
+    <div>
+      <select>
+        <option>value 1</option>
+        <option>value 2</option>
+        <option>value 3</option>
+      </select>
+
+      <select disabled>
+        <option>value 1</option>
+        <option>value 2</option>
+        <option>value 3</option>
+      </select>
+    </div>
+    <div>
+      <progress max="100" value="0"></progress><br>
+      <progress max="100" value="50"></progress><br>
+      <progress max="100" value="100"></progress><br>
+    </div>
+    <div>
+      <meter min="0" max="100" low="33" high="66" optimum="80" value="20"></meter><br>
+      <meter min="0" max="100" low="33" high="66" optimum="80" value="50"></meter><br>
+      <meter min="0" max="100" low="33" high="66" optimum="80" value="90"></meter>
+    </div>
+    <div>
+      <input type="range"><br>
+    </div>
+
+    <script type="text/javascript" src="https://www.unpkg.com/@testing-library/dom@7.5.6/dist/@testing-library/dom.umd.min.js"></script>
+    <script async src="plugin.js"></script>
+  </body>
+</html>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import Embedded from './components/Embedded.js';
+import { AppContextProvider } from './components/Context';
+import '../src/styles/app.pcss';
+
+async function initPlaygrounds() {
+  const root = document.createElement('div');
+  root.setAttribute('id', `testing-playground-${Date.now()}`);
+  document.body.appendChild(root);
+
+  ReactDOM.render(
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 12,
+        left: 12,
+        right: 12,
+        height: 300,
+      }}
+    >
+      <AppContextProvider htmlRoot={document.body}>
+        <Router>
+          <Embedded
+            mode="devtool"
+            panes={['query', 'result']}
+            initialValues={{ markup: '<div />', query: '// foo' }}
+          />
+        </Router>
+      </AppContextProvider>
+    </div>,
+    root,
+  );
+}
+
+function onDocReady(fn) {
+  if (document.readyState !== 'loading') {
+    return fn();
+  }
+
+  setTimeout(() => {
+    onDocReady(fn);
+  }, 9);
+}
+
+onDocReady(initPlaygrounds);


### PR DESCRIPTION
This one is quite awesome!

The query (javascript) is now evaluated in a sandbox! This means, that having `window.location.href = "https://evil.corp"` will no longer redirect the user to a different (potentially bad) domain.

This change also demotes the importance of the `preview` pane. It now only holds a presentation of the `markup`, it's no longer being used to run the queries against. Hence, `htmlRoot` has been removed from the app context.

Thereby, it's no longer required to render the `preview`. Which is especially useful when rendering in embed mode (no hiding-workarounds required).

---

fixes #21 
resolves #66
closes #67