### PR TITLE
feat: support template > script elements without type attribute

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -20,8 +20,9 @@ function initPlaygrounds() {
       markup = playground.content
         .querySelector('script[type="text/html"]')
         ?.innerText.trim();
+
       query = playground.content
-        .querySelector('script[type="text/javascript"]')
+        .querySelector('script[type="text/javascript"], script:not([type])')
         ?.innerText.trim();
 
       const compressed = compress({ markup, query });


### PR DESCRIPTION
The `type` attribute for `script` elements is optional, and defaults to `text/javascript`.

This PR add's support for untyped script elements in embed templates.

The following two examples, are now treated equal:

```html
<template data-testing-playground>
  <script type="text/html">
    <button>one</button>
  </script>

  <script type="text/javascript">
    screen.getByRole('button');
  </script>
</template>
```

```html
<template data-testing-playground>
  <script type="text/html">
    <button>one</button>
  </script>

  <script>
    screen.getByRole('button');
  </script>
</template>
```

