### PR TITLE
fix: prevent WSOD in preview pane

### DIFF
--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -29,7 +29,7 @@ function Preview() {
   const htmlRoot = useRef();
 
   const { suggestion } = getQueryAdvise({
-    rootNode: htmlRoot,
+    rootNode: htmlRoot?.current,
     element: highlighted,
   });
 


### PR DESCRIPTION
I messed up while porting #88 to `develop`