### PR TITLE
chore: import `@testing-library/dom` from npm instead of unpkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,7 +1144,6 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz",
       "integrity": "sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -1786,7 +1785,6 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
       "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
@@ -3192,7 +3190,6 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.9.0.tgz",
       "integrity": "sha512-WYnJx9I94cYKib/Ber2BU3v1dUB+4n5wnJpvWJLTiwgERRTSElsivEtfX5S0LSljS122One6Bewhx2kgoZKXzA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2",
         "aria-query": "^4.0.2",
@@ -3204,7 +3201,6 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -3562,7 +3558,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
       "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.7.4",
         "@babel/runtime-corejs3": "^7.7.4"
@@ -4285,7 +4280,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4717,8 +4711,7 @@
     "core-js-pure": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "dev": true
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prettier": "prettier . --write"
   },
   "dependencies": {
+    "@testing-library/dom": "^7.5.7",
     "codemirror": "5.54.0",
     "dom-accessibility-api": "^0.4.3",
     "js-beautify": "^1.11.0",
@@ -37,7 +38,6 @@
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.9.4",
-    "@testing-library/dom": "^7.5.7",
     "@testing-library/react": "^10.0.4",
     "@testing-library/user-event": "^10.3.5",
     "babel-eslint": "^10.1.0",

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,4 +1,3 @@
-/* global TestingLibraryDom */
 import React, { useRef, useEffect } from 'react';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/xml/xml';
@@ -6,6 +5,7 @@ import 'codemirror/addon/edit/closetag';
 import 'codemirror/addon/fold/xml-fold';
 import 'codemirror/addon/scroll/simplescrollbars';
 import 'codemirror/addon/hint/show-hint';
+import { queries } from '@testing-library/dom';
 
 import CodeMirror from 'codemirror';
 import debounce from 'lodash/debounce';
@@ -36,7 +36,7 @@ const options = {
 };
 
 const suggestions = {
-  screen: Object.keys(TestingLibraryDom.queries)
+  screen: Object.keys(queries)
     .filter((x) => x.startsWith('getBy'))
     .sort(),
   container: ['querySelector', 'querySelectorAll'],

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,6 @@
 
 <body>
     <div id="app"></div>
-    <script type="text/javascript" src="https://www.unpkg.com/@testing-library/dom@7.5.6/dist/@testing-library/dom.umd.min.js"></script>
     <script type="text/javascript" src="index.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
 </body>

--- a/src/parser.js
+++ b/src/parser.js
@@ -3,18 +3,12 @@ import { ensureArray, getQueryAdvise } from './lib';
 import { queries as supportedQueries } from './constants';
 import cssPath from './lib/cssPath';
 
-// this is not the way I want it to be, but I can't get '@testing-library/dom'
-// to build with Parcel. Something with "Incompatible receiver, Map required".
-// It works when running parcel in dev mode, but not in build mode. Seems to
-// have something to do with a core-js Map polyfill being used?
-// It's now loaded from unpkg.com via ./index.html
-//import { getQueriesForElement, queries, logDOM } from '@testing-library/dom';
-const {
+import {
   getQueriesForElement,
   queries,
   getRoles,
   logDOM,
-} = window.TestingLibraryDom;
+} from '@testing-library/dom';
 
 const debug = (element, maxLength, options) =>
   Array.isArray(element)

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -1,7 +1,3 @@
-import * as TestingLibraryDom from '@testing-library/dom';
-
-window.TestingLibraryDom = TestingLibraryDom;
-
 if (window.document) {
   window.document.createRange = () => ({
     setStart: () => {},


### PR DESCRIPTION
This branch builds upon #96. `@testing-library/dom` is now imported from `npm` instead of included from `unpkg.com`