### PR TITLE
chore: remove unpkg import & move service-worker import

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -50,11 +50,6 @@
 
   <body>
     <div id="app"></div>
-    <script
-      type="text/javascript"
-      src="https://www.unpkg.com/@testing-library/dom@7.5.6/dist/@testing-library/dom.umd.min.js"
-    ></script>
-    <script type="text/javascript" src="service-worker.js"></script>
     <script type="text/javascript" src="index.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
   </body>

--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,6 @@ import ReactDOM from 'react-dom';
 import App from './components/App';
 import 'regenerator-runtime/runtime';
 import 'react-toastify/dist/ReactToastify.min.css';
+import './service-worker';
 
 ReactDOM.render(<App />, document.getElementById('app'));


### PR DESCRIPTION
I was quite sure I've removed this one before, not sure why it's there again:

```html
  <script	
      type="text/javascript"	
      src="https://www.unpkg.com/@testing-library/dom@7.5.6/dist/@testing-library/dom.umd.min.js"	
    ></script>
```

Also, instead of importing `service-worker.js` to initialize the service-worker in a separate bundle, I've combined it with the main bundle.